### PR TITLE
Fixed exception occurring when no PRs have been merged since last tag

### DIFF
--- a/src/UnreleasedGitHubHistory/ReleaseNoteFormatter.cs
+++ b/src/UnreleasedGitHubHistory/ReleaseNoteFormatter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -55,7 +56,14 @@ namespace UnreleasedGitHubHistory
             var markdown = new StringBuilder();
 
             if (pullRequests.Any())
+            {
                 markdown.AppendLine($"## {classificationHeading}");
+                foreach (PullRequestDto pullRequest in pullRequests)
+                {
+                    if (pullRequest.Title.Contains("[") && pullRequest.Title.Contains("]"))
+                        pullRequest.Title = EmphasiseSquareBraces(pullRequest.Title);
+                }
+            }
 
             foreach (var app in applicationsLabelMap.OrderBy(a => a.Value))
             {
@@ -77,6 +85,22 @@ namespace UnreleasedGitHubHistory
                     markdown.AppendLine($@"- {EscapeMarkdown(note.Title)} [\#{note.Number}]({gitHubPullRequestUrl}{note.Number})");
             }
             return markdown.ToString();
+        }
+
+        /// <summary>
+        /// Add markup to the outermost square braces.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <returns></returns>
+        private static string EmphasiseSquareBraces(string title)
+        {
+            int firstOpen = title.IndexOf("[", StringComparison.Ordinal);
+            int lastClose = title.LastIndexOf("]", StringComparison.Ordinal);
+
+            if (firstOpen > 0 && lastClose > 0)
+                title = title.Insert(firstOpen, "**").Insert(lastClose + 1, "**");
+
+            return title;
         }
     }
 }

--- a/src/UnreleasedGitHubHistory/ReleaseNoteFormatter.cs
+++ b/src/UnreleasedGitHubHistory/ReleaseNoteFormatter.cs
@@ -97,8 +97,8 @@ namespace UnreleasedGitHubHistory
             int firstOpen = title.IndexOf("[", StringComparison.Ordinal);
             int lastClose = title.LastIndexOf("]", StringComparison.Ordinal);
 
-            if (firstOpen > 0 && lastClose > 0)
-                title = title.Insert(firstOpen, "**").Insert(lastClose + 1, "**");
+            if (firstOpen >= 0 && lastClose > 0)
+                title = title.Insert(firstOpen, "**").Insert(lastClose + 3, "**"); // 1 to move the index after the ']', 2 for the added '**'
 
             return title;
         }

--- a/src/UnreleasedGitHubHistory/UnreleasedGitHubHistoryBuilder.cs
+++ b/src/UnreleasedGitHubHistory/UnreleasedGitHubHistoryBuilder.cs
@@ -49,14 +49,14 @@ namespace UnreleasedGitHubHistory
                         var pullRequest = new PullRequest();
                         if (pullRequestNumber != null)
                             pullRequest = gitHubClient.PullRequest.Get(programArgs.GitHubOwner, programArgs.GitHubRepository, (int)pullRequestNumber).Result;
-                        if (pullRequest == null)
-                            continue;
-                        if (programArgs.VerboseOutput)
-                            Console.WriteLine($"Found #{pullRequest.Number}: {pullRequest.Title}: {mergeCommit.Sha}");
-                        var pullRequestDto = GetPullRequestWithLabels(programArgs, pullRequest, gitHubClient);
-                        if (pullRequestDto == null)
-                            continue;
-                        releaseHistory.Add(pullRequestDto);
+                        if (pullRequest != null && pullRequest.Number > 0)
+                        {
+                            if (programArgs.VerboseOutput)
+                                Console.WriteLine($"Found #{pullRequest.Number}: {pullRequest.Title}: {mergeCommit.Sha}");
+                            var pullRequestDto = GetPullRequestWithLabels(programArgs, pullRequest, gitHubClient);
+                            if (pullRequestDto != null)
+                                releaseHistory.Add(pullRequestDto);
+                        }
                     }
                     return releaseHistory;
                 }


### PR DESCRIPTION
Tested on this repo.
A Pull Request with Number parameter set to 0 isn't really a PR, causes `GetPullRequestWithLabels` to crash (IssueUrl is null).
