### PR TITLE
Improve Performance by Retrieving Information of Pull Requests in Parallel

### DIFF
--- a/src/PullRequestReleaseNotes/PullRequestHistoryBuilder.cs
+++ b/src/PullRequestReleaseNotes/PullRequestHistoryBuilder.cs
@@ -23,7 +23,7 @@ namespace PullRequestReleaseNotes
         public List<PullRequestDto> BuildHistory()
         {
             var unreleasedCommits = GetAllUnreleasedMergeCommits();
-            return unreleasedCommits.Select(mergeCommit => _pullRequestProvider.Get(mergeCommit.Message))
+            return unreleasedCommits.AsParallel().Select(mergeCommit => _pullRequestProvider.Get(mergeCommit.Message))
                 .Where(pullRequestDto => pullRequestDto != null).ToList();
         }
 


### PR DESCRIPTION
may need to tweak if a provider has limited the num of concurrent requests. @jasminsehic can you do the test?

might be a premature optimization as we didn't do a profile first.
