### PR TITLE
Fixed exception when issue body was null

### DIFF
--- a/src/PullRequestReleaseNotes/Extensions.cs
+++ b/src/PullRequestReleaseNotes/Extensions.cs
@@ -30,7 +30,9 @@ namespace PullRequestReleaseNotes
         // convention based link extraction to official documentation, just needs to be prefixed with Doc: or doc: in the pull request body
         public static string ExtractDocumentUrl(this string target)
         {
-	        var matches = Regex.Matches(target,
+            if (target.IsNullOrEmpty())
+                return string.Empty;
+            var matches = Regex.Matches(target,
 		        @"\s*(D|d)oc:\s*(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?").ToList();
 	        if (matches.Any())
 	        {


### PR DESCRIPTION

![firefox_YEUUiWovp1](https://user-images.githubusercontent.com/12790704/61448358-57c84d00-a985-11e9-8aa7-947dba8b4fd6.png)
Some PRs can have null as the issue body which causes regex to throw an exception

This happens if a PR is created programmatically without specifying the optional body parameter