### PR TITLE
Fix: wrong match of tfs pull request number

### DIFF
--- a/src/PullRequestReleaseNotes.Tests/Provider/TfsPullRequestNumberExtractorTests.cs
+++ b/src/PullRequestReleaseNotes.Tests/Provider/TfsPullRequestNumberExtractorTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+using PullRequestReleaseNotes.Providers;
+using Shouldly;
+
+namespace PullRequestReleaseNotes.Tests.Provider
+{
+    [TestFixture]
+    public class TfsPullRequestNumberExtractorTests
+    {
+        [TestCase("Merge pull request 123: fix a bug", 123)]
+        [TestCase("Merged PR 123: fix a bug", 123)]
+        [TestCase("t 123: number 123 was was extracted by the old code", null)]
+        public void CanExtractPullRequestNumber(string commit, int? expected)
+        {
+            TfsPullRequestNumberExtractor.Extract(commit).ShouldBe(expected);
+        }
+    }
+}

--- a/src/PullRequestReleaseNotes.Tests/PullRequestReleaseNotes.Tests.csproj
+++ b/src/PullRequestReleaseNotes.Tests/PullRequestReleaseNotes.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <IsPublishable>false</IsPublishable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PullRequestReleaseNotes\PullRequestReleaseNotes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/PullRequestReleaseNotes.Tests/PullRequestReleaseNotes.Tests.csproj
+++ b/src/PullRequestReleaseNotes.Tests/PullRequestReleaseNotes.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />

--- a/src/PullRequestReleaseNotes.Tests/RepoHelper.cs
+++ b/src/PullRequestReleaseNotes.Tests/RepoHelper.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using LibGit2Sharp;
+
+namespace PullRequestReleaseNotes.Tests
+{
+    internal class RepoHelper : IDisposable
+    {
+        private readonly string _repoFolder;
+        public readonly Repository Repo;
+        private static Signature Author => new Signature("user", "email@email.com", DateTime.Now);
+
+
+        public RepoHelper(string repoFolder)
+        {
+            _repoFolder = repoFolder;
+            Repository.Init(_repoFolder);
+            Repo = new Repository(_repoFolder);
+        }
+
+
+        public void MakeACommit(string commitMsg)
+        {
+            var file = Path.Combine(_repoFolder, Guid.NewGuid().ToString());
+            File.WriteAllText(file, commitMsg);
+            CommitFile(commitMsg, file);
+        }
+
+        private void CommitFile(string commitMsg, string file)
+        {
+            Commands.Stage(Repo, file);
+            Repo.Commit(commitMsg, Author, Author);
+        }
+
+        public void CreateTag(string tag)
+        {
+            Repo.ApplyTag(tag);
+            // we may sort by tag creation time, so sleep to make sure we don't create tags at exactly the same second
+            Thread.Sleep(TimeSpan.FromSeconds(1)); 
+        }
+
+        public void CreateAnnotatedTag(string tag)
+        {
+            Repo.ApplyTag(tag, Repo.Head.Tip.Sha, Author, "message for tag");
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+        }
+
+        public string CreateAndCheckoutBranch(string branch)
+        {
+            Repo.CreateBranch(branch);
+            Commands.Checkout(Repo, branch);
+            return branch;
+        }
+
+        public void CheckoutBranch(string branch)
+        {
+            Commands.Checkout(Repo, branch);
+        }
+        public void Dispose()
+        {
+            Repo.Dispose();
+            var directory = new DirectoryInfo(_repoFolder) { Attributes = FileAttributes.Normal };
+
+            foreach (var info in directory.GetFileSystemInfos("*", SearchOption.AllDirectories))
+            {
+                info.Attributes = FileAttributes.Normal;
+            }
+
+            directory.Delete(true);
+        }
+
+        public Commit MergeBranch(string branch)
+        {
+            var result = Repo.Merge(Repo.Branches[branch], Author,
+                new MergeOptions {FastForwardStrategy = FastForwardStrategy.NoFastForward});
+            return result.Commit;
+        }
+    }
+}

--- a/src/PullRequestReleaseNotes.Tests/TestBase.cs
+++ b/src/PullRequestReleaseNotes.Tests/TestBase.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace PullRequestReleaseNotes.Tests
+{
+    internal abstract class TestBase
+    {
+        protected RepoHelper RepoHelper;
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            var repoFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "PrReleaseNoteTestRepo", Guid.NewGuid().ToString());
+            RepoHelper = new RepoHelper(repoFolder);
+            RepoHelper.MakeACommit("init");
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            RepoHelper.Dispose();
+        }
+    }
+}

--- a/src/PullRequestReleaseNotes.Tests/UnreleasedCommitsProviderTests.cs
+++ b/src/PullRequestReleaseNotes.Tests/UnreleasedCommitsProviderTests.cs
@@ -1,0 +1,375 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Shouldly;
+
+namespace PullRequestReleaseNotes.Tests
+{
+    [TestFixture]
+    internal class UnreleasedCommitsProviderTests : TestBase
+    {
+        private UnreleasedCommitsProvider _unreleasedCommitsProvider;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+            _unreleasedCommitsProvider = new UnreleasedCommitsProvider();
+        }
+
+        /// <summary>
+        ///  init
+        ///   |-----(create feature1 branch from here)
+        ///   |   |
+        ///   |   |-feature 1 (commit a feature)
+        ///   |   /
+        ///   |  /
+        ///   | /
+        ///   |/ (merge feature1 into release-1)
+        /// </summary>
+        [Test]
+        public void SimplestCase()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+            var feature1 = CreateBranchAndCommit("feature-1");
+
+            RepoHelper.CheckoutBranch(main);
+
+            var theMergeCommit = RepoHelper.MergeBranch(feature1);
+
+            var commits = _unreleasedCommitsProvider
+                .GetAllUnreleasedMergeCommits(RepoHelper.Repo, main, annotatedTagOnly: false)
+                .ToList();
+
+            commits.Count.ShouldBe(1);
+            commits[0].Sha.ShouldBe(theMergeCommit.Sha);
+        }
+
+        /// <summary>
+        /// init
+        ///   |-----(create feature1 branch from here)
+        ///   |   |
+        ///   |   |-feature 1 commit
+        ///   |   /
+        ///   |  /
+        ///   | /
+        ///   |/ (merge feature1)
+        ///   |
+        ///   |-----(create feature2 branch from here)
+        ///   |   |
+        ///   |   |-feature 2 commit
+        ///   |  /
+        ///   | /
+        ///   |/ (merge feature2)
+        /// </summary>
+        [Test]
+        public void AbleToGetMultipleCommitsMergedFromDifferentBranches()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+
+            RepoHelper.CheckoutBranch(main);
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+
+            var commits= _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+            commits.Count().ShouldBe(2);
+            commits.Single(x => x.Sha == mergeFeature1.Sha).ShouldNotBeNull();
+            commits.Single(x => x.Sha == mergeFeature2.Sha).ShouldNotBeNull();
+        }
+
+        private string CreateBranchAndCommit(string branch)
+        {
+            RepoHelper.CreateAndCheckoutBranch(branch);
+            RepoHelper.MakeACommit($"{branch} implemented");
+            return branch;
+        }
+
+        [Test]
+        public void ExcludeCommitsNotInCurrentBranch()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+
+            RepoHelper.CheckoutBranch(main);
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(1);
+            commits.Single(x => x.Sha == mergeFeature2.Sha).ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// init
+        ///   |-----(create feature branch from here)
+        ///   |   |
+        ///   |   |-feature 1 commit
+        ///   |   /
+        ///   |  /
+        ///   | /
+        ///   |/ (merge feature1)
+        ///   |
+        ///   - tag 1.0.0 here
+        ///   |-----(create feature2 branch from here)
+        ///   |   |
+        ///   |   |-feature 2 commit
+        ///   |  /
+        ///   | /
+        ///   |/ (merge feature2)
+        /// </summary>
+        [Test]
+        public void ExcludeCommitsAlreadyReleased()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+            RepoHelper.CreateTag("1.0.0");
+
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(1);
+            commits.ShouldContain(x => x.Sha == mergeFeature2.Sha);
+        }
+
+        /// <summary>
+        /// init
+        ///   |-------------------------------------------------------
+        ///   |   |                                                 |
+        ///   |   |-feature 1 commit                                |
+        ///   |   /                                                 |-feature2 commit  
+        ///   |  /                                                  /
+        ///   | /                                                  /
+        ///   |/ (merge feature1)                                 /
+        ///   |                                                  /
+        ///   - tag 1.0.0 here for release1                     / 
+        ///   |                                                /
+        ///   |                                               /
+        ///   |                                              /
+        ///   |                                             /
+        ///   |                                            /
+        ///   |______________merge feature2 to main ______/
+        ///   |
+        ///   |
+        /// </summary>
+        [Test]
+        public void ExcludeCommitsAlreadyReleasedWhenMultipleFeaturesInParallel()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+            
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+            RepoHelper.CreateTag("1.0.0");
+
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(1);
+            commits.ShouldNotContain(x => x.Sha == mergeFeature1.Sha);
+            commits.ShouldContain(x => x.Sha == mergeFeature2.Sha);
+        }
+
+        /// <summary>
+        /// init
+        ///   |----
+        ///   |   |                         
+        ///   |   |-feature 1 commit       
+        ///   |   /                      
+        ///   |  /                        
+        ///   | /                       
+        ///   |/ (merge feature1)      
+        ///   |                       
+        ///   - tag 1.0.0 here for release1
+        ///   |   |                          
+        ///   |   |-feature 2 commit        
+        ///   |   /                        
+        ///   |  /                        
+        ///   | /                        
+        ///   |/ (merge feature2)       
+        ///   - tag 2.0.0 here for release2
+        ///   |   |
+        ///   |   |                          
+        ///   |   |-feature 3 commit        
+        ///   |   /                        
+        ///   |  /                        
+        ///   | /                        
+        ///   |/ (merge feature3)       
+        /// </summary>
+        [Test]
+        public void CanExcludeFromMultipleTags()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+            RepoHelper.CreateTag("1.0.0");
+
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+            RepoHelper.CreateTag("2.0.0");
+
+            var feature3Branch = CreateBranchAndCommit("feature3-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature3 = RepoHelper.MergeBranch(feature3Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(1);
+            commits.ShouldContain(x => x.Sha == mergeFeature3.Sha);
+        }
+
+        /// <summary>
+        /// init
+        ///   | tag 1.0.0
+        ///   |--------------------------------------------------
+        ///   |   |                                        |    |
+        ///   |   |-feature 2 commit                       |    |
+        ///   |   /                                        |    | - fix 1
+        ///   |  /               release branch for defect |    |
+        ///   | /                                          |   /
+        ///   |/ (merge feature2)                          |  /
+        ///   |                                            | /
+        ///   |---- tag 2.0.0                              |/
+        ///   |   |                                        | tag 1.0.1
+        ///   |   |                                       /
+        ///   |   |                                      /
+        ///   |   |                                     /
+        ///   |____________merge fix 1 to main_________/
+        ///   |   |                          
+        ///   |   |-feature 3 commit        
+        ///   |   /                        
+        ///   |  /                        
+        ///   | /                        
+        ///   |/ (merge feature3)
+        ///   |
+        /// </summary>
+        [Test]
+        public void CanExcludeFromMultipleTagsWhenMultipleReleasesInParallel()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+            RepoHelper.CreateTag("1.0.0");
+
+            var releaseBranchForBugFix = RepoHelper.CreateAndCheckoutBranch("release-branch-for-bug1");
+            var bugFix1Branch = CreateBranchAndCommit("bug-fix1-branch");
+            RepoHelper.CheckoutBranch(releaseBranchForBugFix);
+            var mergeBugFix1 = RepoHelper.MergeBranch(bugFix1Branch);
+            RepoHelper.CreateTag("1.0.1");
+
+            RepoHelper.CheckoutBranch(main);
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+            RepoHelper.CreateTag("2.0.0");
+
+            var mergeBugFixReleaseToMain = RepoHelper.MergeBranch(releaseBranchForBugFix);
+
+            var feature3Branch = CreateBranchAndCommit("feature3-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature3 = RepoHelper.MergeBranch(feature3Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(2);
+            commits.ShouldNotContain(x => x.Sha == mergeFeature2.Sha);
+            commits.ShouldNotContain(x => x.Sha == mergeBugFix1.Sha);
+            commits.ShouldContain(x => x.Sha == mergeFeature3.Sha);
+            commits.ShouldContain(x => x.Sha == mergeBugFixReleaseToMain.Sha);
+        }
+
+        /// <summary>
+        /// init
+        ///   |-----------
+        ///   |          |                
+        ///   |          |-feature 1 commit
+        ///   |         /|               
+        ///   |        / | 
+        ///   |       /  |
+        ///   |      /   | release feature on non-main branch
+        ///   |     /    | tag 1.0.0       
+        ///   |____/     
+        ///   |             
+        /// </summary>
+        [Test]
+        public void IncludeEvenReleasedInAnotherBranch()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+
+            RepoHelper.CheckoutBranch(feature1Branch);
+            RepoHelper.CreateTag("1.0.0");
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(1);
+            commits.ShouldContain(x => x.Sha == mergeFeature1.Sha);
+        }
+
+        [Test]
+        public void AbleToWorkWithAnnotatedTag()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+            RepoHelper.CreateAnnotatedTag("1.0.0");
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: false).ToList();
+
+            commits.Count().ShouldBe(1);
+            commits.ShouldContain(x => x.Sha == mergeFeature2.Sha);
+        }
+
+        [Test]
+        public void IgnoreLightTagWhenInAnnotatedOnlyMode()
+        {
+            var main = RepoHelper.CreateAndCheckoutBranch("main");
+            var feature1Branch = CreateBranchAndCommit("feature1-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature1 = RepoHelper.MergeBranch(feature1Branch);
+            RepoHelper.CreateTag("1.0.0");
+            var feature2Branch = CreateBranchAndCommit("feature2-branch");
+            RepoHelper.CheckoutBranch(main);
+            var mergeFeature2 = RepoHelper.MergeBranch(feature2Branch);
+
+            var commits = _unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(RepoHelper.Repo, main,
+                annotatedTagOnly: true).ToList();
+
+            commits.Count().ShouldBe(2);
+            commits.ShouldContain(x => x.Sha == mergeFeature1.Sha);
+            commits.ShouldContain(x => x.Sha == mergeFeature2.Sha);
+        }
+    }
+}

--- a/src/PullRequestReleaseNotes.sln
+++ b/src/PullRequestReleaseNotes.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PullRequestReleaseNotes", "PullRequestReleaseNotes\PullRequestReleaseNotes.csproj", "{B7A7DF45-4248-4784-8417-594F15B7484A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PullRequestReleaseNotes", "PullRequestReleaseNotes\PullRequestReleaseNotes.csproj", "{B7A7DF45-4248-4784-8417-594F15B7484A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PullRequestReleaseNotes.Tests", "PullRequestReleaseNotes.Tests\PullRequestReleaseNotes.Tests.csproj", "{C3288F1C-4667-4D65-9863-00EB66C3A8E8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{B7A7DF45-4248-4784-8417-594F15B7484A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7A7DF45-4248-4784-8417-594F15B7484A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7A7DF45-4248-4784-8417-594F15B7484A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3288F1C-4667-4D65-9863-00EB66C3A8E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3288F1C-4667-4D65-9863-00EB66C3A8E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3288F1C-4667-4D65-9863-00EB66C3A8E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3288F1C-4667-4D65-9863-00EB66C3A8E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7356BB34-F778-432B-AD86-DCCE1F4224B2}
 	EndGlobalSection
 EndGlobal

--- a/src/PullRequestReleaseNotes/Providers/TfsPullRequestNumberExtractor.cs
+++ b/src/PullRequestReleaseNotes/Providers/TfsPullRequestNumberExtractor.cs
@@ -6,7 +6,7 @@ namespace PullRequestReleaseNotes.Providers
     {
         public static int? Extract(string commitMessage)
         {
-            var pattern = new Regex(@"[Merge pull request|Merged PR] (?<pullRequestNumber>\d+).*");
+            var pattern = new Regex(@"(Merge pull request|Merged PR) (?<pullRequestNumber>\d+).*");
             var match = pattern.Match(commitMessage);
             if (match.Groups.Count <= 0 || !match.Groups["pullRequestNumber"].Success)
                 return null;

--- a/src/PullRequestReleaseNotes/Providers/TfsPullRequestNumberExtractor.cs
+++ b/src/PullRequestReleaseNotes/Providers/TfsPullRequestNumberExtractor.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.RegularExpressions;
+
+namespace PullRequestReleaseNotes.Providers
+{
+    public static class TfsPullRequestNumberExtractor
+    {
+        public static int? Extract(string commitMessage)
+        {
+            var pattern = new Regex(@"[Merge pull request|Merged PR] (?<pullRequestNumber>\d+).*");
+            var match = pattern.Match(commitMessage);
+            if (match.Groups.Count <= 0 || !match.Groups["pullRequestNumber"].Success)
+                return null;
+            return int.Parse(match.Groups["pullRequestNumber"].Value);
+        }
+    }
+}

--- a/src/PullRequestReleaseNotes/Providers/TfsPullRequestProvider.cs
+++ b/src/PullRequestReleaseNotes/Providers/TfsPullRequestProvider.cs
@@ -187,11 +187,7 @@ namespace PullRequestReleaseNotes.Providers
 
         private static int? ExtractPullRequestNumber(string commitMessage)
         {
-            var pattern = new Regex(@"[Merge pull request|Merged PR] (?<pullRequestNumber>\d+).*");
-            var match = pattern.Match(commitMessage);
-            if (match.Groups.Count <= 0 || !match.Groups["pullRequestNumber"].Success)
-                return null;
-            return int.Parse(match.Groups["pullRequestNumber"].Value);
+            return TfsPullRequestNumberExtractor.Extract(commitMessage);
         }
     }
 }

--- a/src/PullRequestReleaseNotes/PullRequestHistoryBuilder.cs
+++ b/src/PullRequestReleaseNotes/PullRequestHistoryBuilder.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Linq;
-using LibGit2Sharp;
+﻿using System.Linq;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using PullRequestReleaseNotes.Models;
 using PullRequestReleaseNotes.Providers;
 
@@ -12,7 +9,6 @@ namespace PullRequestReleaseNotes
     {
         private readonly ProgramArgs _programArgs;
         private readonly IPullRequestProvider _pullRequestProvider;
-        private static readonly Regex ParseSemVer = new Regex(@"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$", RegexOptions.Compiled);
 
         public PullRequestHistoryBuilder(ProgramArgs programArgs)
         {
@@ -22,46 +18,11 @@ namespace PullRequestReleaseNotes
 
         public List<PullRequestDto> BuildHistory()
         {
-            var unreleasedCommits = GetAllUnreleasedMergeCommits();
+            var unreleasedCommitsProvider = new UnreleasedCommitsProvider();
+            var unreleasedCommits = unreleasedCommitsProvider.GetAllUnreleasedMergeCommits(
+                _programArgs.LocalGitRepository, _programArgs.ReleaseBranchRef, _programArgs.GitTagsAnnotated);
             return unreleasedCommits.Select(mergeCommit => _pullRequestProvider.Get(mergeCommit.Message))
                 .Where(pullRequestDto => pullRequestDto != null).ToList();
-        }
-
-        private IEnumerable<Commit> GetAllUnreleasedMergeCommits()
-        {
-            var releasedCommitsHash = new Dictionary<string, Commit>();
-            var branchReference = _programArgs.LocalGitRepository.Branches[_programArgs.ReleaseBranchRef];
-            var tagCommits = _programArgs.LocalGitRepository.Tags
-                .Where(LightOrAnnotatedTags())
-                .Where(t => ParseSemVer.Match(t.FriendlyName).Success)
-                .Select(tag => tag.Target as Commit).Where(x => x != null).ToList();
-            var branchAncestors = _programArgs.LocalGitRepository.Commits
-                .QueryBy(new CommitFilter { IncludeReachableFrom = branchReference })
-                .Where(commit => commit.Parents.Count() > 1);
-            if (!tagCommits.Any())
-                return branchAncestors;
-            // for each tagged commit walk down all its parents and collect a dictionary of unique commits
-            foreach (var tagCommit in tagCommits)
-            {
-                // we only care about tags descending from the branch we are interested in
-                if (_programArgs.LocalGitRepository.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = branchReference }).Any(c => c.Sha == tagCommit.Sha))
-                {
-                    var releasedCommits = _programArgs.LocalGitRepository.Commits
-                        .QueryBy(new CommitFilter { IncludeReachableFrom = tagCommit.Id })
-                        .Where(commit => commit.Parents.Count() > 1)
-                        .ToDictionary(i => i.Sha, i => i);
-                    releasedCommitsHash.Merge(releasedCommits);
-                }
-            }
-            // remove released commits from the branch ancestor commits as they have been previously released
-            return branchAncestors.Except(releasedCommitsHash.Values.AsEnumerable());
-        }
-
-        private Func<Tag, bool> LightOrAnnotatedTags()
-        {
-            if (_programArgs.GitTagsAnnotated)
-                return t => t.IsAnnotated;
-            return t => true;
         }
     }
 }

--- a/src/PullRequestReleaseNotes/UnreleasedCommitsProvider.cs
+++ b/src/PullRequestReleaseNotes/UnreleasedCommitsProvider.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using LibGit2Sharp;
+
+namespace PullRequestReleaseNotes
+{
+    public class UnreleasedCommitsProvider
+    {
+        private static readonly Regex ParseSemVer = new Regex(@"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$", RegexOptions.Compiled);
+        private static Func<Tag, bool> LightOrAnnotatedTags(bool annotatedTagOnly)
+        {
+            if (annotatedTagOnly)
+                return t => t.IsAnnotated;
+            return t => true;
+        }
+        public IEnumerable<Commit> GetAllUnreleasedMergeCommits(IRepository repo, string releaseBranchRef, bool annotatedTagOnly)
+        {
+            var releasedCommitsHash = new Dictionary<string, Commit>();
+            var branchReference = repo.Branches[releaseBranchRef];
+            var tagCommits = repo.Tags
+                .Where(LightOrAnnotatedTags(annotatedTagOnly))
+                .Where(t => ParseSemVer.Match(t.FriendlyName).Success)
+                .Select(tag => tag.Target as Commit).Where(x => x != null).ToList();
+            var branchAncestors = repo.Commits
+                .QueryBy(new CommitFilter { IncludeReachableFrom = branchReference })
+                .Where(commit => commit.Parents.Count() > 1);
+            if (!tagCommits.Any())
+                return branchAncestors;
+            // for each tagged commit walk down all its parents and collect a dictionary of unique commits
+            foreach (var tagCommit in tagCommits)
+            {
+                // we only care about tags descending from the branch we are interested in
+                if (repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = branchReference }).Any(c => c.Sha == tagCommit.Sha))
+                {
+                    var releasedCommits = repo.Commits
+                        .QueryBy(new CommitFilter { IncludeReachableFrom = tagCommit.Id })
+                        .Where(commit => commit.Parents.Count() > 1)
+                        .ToDictionary(i => i.Sha, i => i);
+                    releasedCommitsHash.Merge(releasedCommits);
+                }
+            }
+            // remove released commits from the branch ancestor commits as they have been previously released
+            return branchAncestors.Except(releasedCommitsHash.Values.AsEnumerable());
+        }
+    }
+}


### PR DESCRIPTION
The previous code matches any single char in `[Merge pull request|Merged PR]`