### PR TITLE
Fix: unable to publish to confluence with null fields in the JSON

### DIFF
--- a/src/PullRequestReleaseNotes/Publishers/ConfluencePublisher.cs
+++ b/src/PullRequestReleaseNotes/Publishers/ConfluencePublisher.cs
@@ -124,7 +124,10 @@ namespace PullRequestReleaseNotes.Publishers
         }
         private static void AddJsonBodyToRequest(Content page, RestRequest request)
         {
-            var json = JsonConvert.SerializeObject(page);
+            var json = JsonConvert.SerializeObject(page, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            });
             request.AddParameter("application/json", json, ParameterType.RequestBody);
         }
     }

--- a/src/PullRequestReleaseNotes/Publishers/ConfluencePublisher.cs
+++ b/src/PullRequestReleaseNotes/Publishers/ConfluencePublisher.cs
@@ -57,7 +57,12 @@ namespace PullRequestReleaseNotes.Publishers
                 Ancestors = new[] { new Ancestor() { Id = programArgs.ConfluenceReleaseParentPageId, Type = "page" } },
                 Body = new Body { Storage = BuildMarkdownBodyContent(markdown) }
             };
-            return PostConfluenceContent(programArgs, page).StatusCode == HttpStatusCode.OK;
+            var resp = PostConfluenceContent(programArgs, page);
+            if (resp.StatusCode != HttpStatusCode.OK)
+            {
+                Console.Error.WriteLine($"Failed to publish to confluence: {resp.Content}");
+            }
+            return resp.StatusCode == HttpStatusCode.OK;
         }
 
         private static bool UpdateConfluencePage(ProgramArgs programArgs, Content existingPage, string markdown)


### PR DESCRIPTION
Confluence API has a recent change to disallow null fields in the JSON body thus the failure.